### PR TITLE
Pantheon: add checks for multidev environments before creating or deleting.

### DIFF
--- a/.github/workflows/00-pantheon-create-multidev.yml
+++ b/.github/workflows/00-pantheon-create-multidev.yml
@@ -73,10 +73,11 @@ jobs:
             -- $PANTHEON_MACHINE_NAME \
             | grep ${{ steps.safe_branch.outputs.branch_name }})
 
-          echo "${multidev_list}"
-
           # Provide the list to the Github output.
-          echo "${multidev_list}" >> "$GITHUB_OUTPUT"
+          delimiter="$(openssl rand -hex 8)"
+          echo "multidev_list<<${delimiter}" >> "${GITHUB_OUTPUT}"
+          echo ${multidev_list} >> ${GITHUB_OUTPUT}
+          echo "${delimiter}" >> "${GITHUB_OUTPUT}"
 
       - name: Create a multidev environment.
         # Only create the environment if it doesn't already exist.

--- a/.github/workflows/00-pantheon-create-multidev.yml
+++ b/.github/workflows/00-pantheon-create-multidev.yml
@@ -60,7 +60,21 @@ jobs:
         with:
           pantheon-machine-token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
 
-      - name: Create or update a multidev environment.
+      - name: Check for existing multidev.
+        id: check_existing
+        run: |
+          # Get the multidev list and grep for the branch name passed in.
+          multidev_list=$(terminus multidev:list \
+            --no-interaction \
+            --format=list \
+            -- $PANTHEON_MACHINE_NAME \
+            | grep ${{ steps.safe_branch.outputs.branch_name }}
+          # Provide the list to the Github output.
+          echo ${multidev_list} >> ${GITHUB_OUTPUT}
+
+      - name: Create a multidev environment.
+        # Only create the environment if it doesn't already exist.
+        if: steps.check_existing.outputs.multidev_list == ''
         env:
           PANTHEON_SITE_URL: "pantheonsite.io"
         run: |
@@ -69,4 +83,11 @@ jobs:
             --no-files \
             --no-interaction
           echo "⚡ Multidev site created!" >> $GITHUB_STEP_SUMMARY
+          echo "You can access it at: https://${{ steps.safe_branch.outputs.branch_name }}-$PANTHEON_MACHINE_NAME.$PANTHEON_SITE_URL" >> $GITHUB_STEP_SUMMARY
+
+      - name: Provide the multidev environment URL.
+        # If a multidev environment already exists, list it.
+        if: steps.check_existing.outputs.multidev_list != ''
+        run: |
+          echo "⚡ Multidev site already exists! It's being updated." >> $GITHUB_STEP_SUMMARY
           echo "You can access it at: https://${{ steps.safe_branch.outputs.branch_name }}-$PANTHEON_MACHINE_NAME.$PANTHEON_SITE_URL" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/00-pantheon-create-multidev.yml
+++ b/.github/workflows/00-pantheon-create-multidev.yml
@@ -68,7 +68,7 @@ jobs:
             --no-interaction \
             --format=list \
             -- $PANTHEON_MACHINE_NAME \
-            | grep ${{ steps.safe_branch.outputs.branch_name }}
+            | grep ${{ steps.safe_branch.outputs.branch_name }})
           # Provide the list to the Github output.
           echo ${multidev_list} >> ${GITHUB_OUTPUT}
 

--- a/.github/workflows/00-pantheon-create-multidev.yml
+++ b/.github/workflows/00-pantheon-create-multidev.yml
@@ -73,8 +73,10 @@ jobs:
             -- $PANTHEON_MACHINE_NAME \
             | grep ${{ steps.safe_branch.outputs.branch_name }})
 
+          echo "${multidev_list}"
+
           # Provide the list to the Github output.
-          echo ${multidev_list} >> ${GITHUB_OUTPUT}
+          echo "${multidev_list}" >> "$GITHUB_OUTPUT"
 
       - name: Create a multidev environment.
         # Only create the environment if it doesn't already exist.

--- a/.github/workflows/00-pantheon-create-multidev.yml
+++ b/.github/workflows/00-pantheon-create-multidev.yml
@@ -62,6 +62,9 @@ jobs:
 
       - name: Check for existing multidev.
         id: check_existing
+        # Terminus returns an error/warning if there are no multidevs at all;
+        # this shouldn't stop the build from continuing.
+        continue-on-error: true
         run: |
           # Get the multidev list and grep for the branch name passed in.
           multidev_list=$(terminus multidev:list \

--- a/.github/workflows/00-pantheon-create-multidev.yml
+++ b/.github/workflows/00-pantheon-create-multidev.yml
@@ -72,6 +72,7 @@ jobs:
             --format=list \
             -- $PANTHEON_MACHINE_NAME \
             | grep ${{ steps.safe_branch.outputs.branch_name }})
+
           # Provide the list to the Github output.
           echo ${multidev_list} >> ${GITHUB_OUTPUT}
 

--- a/.github/workflows/00-pantheon-remove-branch.yml
+++ b/.github/workflows/00-pantheon-remove-branch.yml
@@ -74,6 +74,9 @@ jobs:
 
       - name: Check whether multidev exists.
         id: check_existing
+        # Terminus returns an error/warning if there are no multidevs at all;
+        # this shouldn't stop the build from continuing.
+        continue-on-error: true
         run: |
           # Get the multidev list and grep for the branch name passed in.
           multidev_list=$(terminus multidev:list \

--- a/.github/workflows/00-pantheon-remove-branch.yml
+++ b/.github/workflows/00-pantheon-remove-branch.yml
@@ -86,7 +86,7 @@ jobs:
             | grep ${{ steps.safe_branch.outputs.branch_name }})
 
           # Provide the list to the Github output.
-          echo ${multidev_list} >> ${GITHUB_OUTPUT}
+          echo "${multidev_list}" >> "$GITHUB_OUTPUT"
 
       - name: Delete a multidev environment.
         # If there was a multidev environment, delete it, and the branch.

--- a/.github/workflows/00-pantheon-remove-branch.yml
+++ b/.github/workflows/00-pantheon-remove-branch.yml
@@ -86,7 +86,10 @@ jobs:
             | grep ${{ steps.safe_branch.outputs.branch_name }})
 
           # Provide the list to the Github output.
-          echo "${multidev_list}" >> "$GITHUB_OUTPUT"
+          delimiter="$(openssl rand -hex 8)"
+          echo "multidev_list<<${delimiter}" >> "${GITHUB_OUTPUT}"
+          echo ${multidev_list} >> ${GITHUB_OUTPUT}
+          echo "${delimiter}" >> "${GITHUB_OUTPUT}"
 
       - name: Delete a multidev environment.
         # If there was a multidev environment, delete it, and the branch.

--- a/.github/workflows/00-pantheon-remove-branch.yml
+++ b/.github/workflows/00-pantheon-remove-branch.yml
@@ -80,7 +80,7 @@ jobs:
             --no-interaction \
             --format=list \
             -- $PANTHEON_MACHINE_NAME \
-            | grep ${{ steps.safe_branch.outputs.branch_name }}
+            | grep ${{ steps.safe_branch.outputs.branch_name }})
           # Provide the list to the Github output.
           echo ${multidev_list} >> ${GITHUB_OUTPUT}
 

--- a/.github/workflows/00-pantheon-remove-branch.yml
+++ b/.github/workflows/00-pantheon-remove-branch.yml
@@ -84,6 +84,7 @@ jobs:
             --format=list \
             -- $PANTHEON_MACHINE_NAME \
             | grep ${{ steps.safe_branch.outputs.branch_name }})
+
           # Provide the list to the Github output.
           echo ${multidev_list} >> ${GITHUB_OUTPUT}
 

--- a/.github/workflows/00-pantheon-remove-branch.yml
+++ b/.github/workflows/00-pantheon-remove-branch.yml
@@ -72,9 +72,21 @@ jobs:
         with:
           pantheon-machine-token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
 
+      - name: Check whether multidev exists.
+        id: check_existing
+        run: |
+          # Get the multidev list and grep for the branch name passed in.
+          multidev_list=$(terminus multidev:list \
+            --no-interaction \
+            --format=list \
+            -- $PANTHEON_MACHINE_NAME \
+            | grep ${{ steps.safe_branch.outputs.branch_name }}
+          # Provide the list to the Github output.
+          echo ${multidev_list} >> ${GITHUB_OUTPUT}
+
       - name: Delete a multidev environment.
-        # Don't mark this as a build fail if the multi-dev doesn't delete.
-        # Maybe there wasn't a multi-dev to delete.
+        # If there was a multidev environment, delete it, and the branch.
+        if: steps.check_existing.outputs.multidev_list != ''
         continue-on-error: true
         run: |
           terminus multidev:delete \
@@ -82,41 +94,18 @@ jobs:
             --yes \
             --no-interaction \
             --delete-branch
-          echo "🌩️ ${{ steps.safe_branch.outputs.branch_name }} multi-dev site deleted!" >> $GITHUB_STEP_SUMMARY
-
-  delete-branch:
-    name: 'Delete the branch from Pantheon'
-    runs-on: ubuntu-latest
-    env:
-      COMMIT_REF: ${{ github.head_ref }}
-      REMOTE_REPO: ${{ secrets.REMOTE_REPO }}
-    steps:
-      # It's safe to use a checkout here, instead of the cached build, just to
-      # get access to the script.
-      - name: Check out the code
-        uses: actions/checkout@v6
-
-      - name: Set up the SSH key and configuration.
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.REMOTE_SSH_KEY }}
-          config: ${{ secrets.SSH_CONFIG }}
-          known_hosts: ${{ secrets.KNOWN_HOSTS }}
-
-      - name: Create multi-dev-safe branch name.
-        id: safe_branch
-        uses: thisisgain/.github/.github/actions/pantheon-safe-branch@main
-        with:
-          branch_name: ${{ github.head_ref }}
-          strip_prefix: strip_prefix
-          safe_prefix: safe_prefix
+          echo "🌩️ ${{ steps.safe_branch.outputs.branch_name }} multi-dev site, and associated branch, deleted!" >> $GITHUB_STEP_SUMMARY
 
       - name: Add Pantheon as a remote.
+        # If there was no multidev, delete the remote branch only.
+        if: steps.check_existing.outputs.multidev_list == ''
         run: |
           git config --global --add safe.directory $(realpath .)
           git remote add pantheon $REMOTE_REPO
 
       - name: Delete the branch from Pantheon.
+        # If there was no multidev, delete the remote branch only.
+        if: steps.check_existing.outputs.multidev_list != ''
         # Don't mark this as a build fail if the branch doesn't delete.
         continue-on-error: true
         run: |


### PR DESCRIPTION
Something that's annoyed me for some time: if you add the "Build" label to a pull request, it'll create a multidev environment; if you push an upddate, it'll try to create the multidev again, and the build will fail. 

This adds a step to both the create & delete workflows to check whether a multidev environment exists before ploughing ahead.

I used Adder to check this. When a PR is created with the "Build" label, it runs the workflow twice - once because it's a PR, and once because it's been labelled (since Github counts them separately), so that works quite nicely for checking that this worked!
* PR: https://github.com/accessdigital/adder/pull/668 
* Successful build - PR created, multidev environment created: https://github.com/accessdigital/adder/actions/runs/25217141510
* Successful build - label added, multidev environment not created as it already exists: https://github.com/accessdigital/adder/actions/runs/25217141513

Now ready for review! 