### PR TITLE
Switch some secrets to variables and perform some housekeeping

### DIFF
--- a/.github/examples/build-deploy-artifact-remote-repository.yml
+++ b/.github/examples/build-deploy-artifact-remote-repository.yml
@@ -62,8 +62,9 @@ jobs:
       # The commit details should be an automation account, with a shared email;
       # the SSH config in secrets use these credentials, and the user should be
       # able to access the remote repo (eg add as a user).
-      git_name: GAIN Automation
-      git_email: geeks+client.gha@thisisgain.com
+      # Git user details, including SSH keys, should be stored in Keeper.
+      git_name: ${{ vars.git_name }}
+      git_email: ${{ vars.git_email }}
       source_key: theme
       # Skip adding the default set of files.
       add_files_defaults: false

--- a/.github/examples/build-deploy-pantheon-multidev.yml
+++ b/.github/examples/build-deploy-pantheon-multidev.yml
@@ -51,8 +51,9 @@ jobs:
       # The commit details should be an automation account, with a shared email;
       # the SSH config in secrets use these credentials, and the user should be
       # able to access the remote repo (eg add as a user).
-      git_name: GAIN Automation
-      git_email: geeks+client.gha@thisisgain.com
+      # Git user details, including SSH keys, should be stored in Keeper.
+      git_name: ${{ vars.git_name }}
+      git_email: ${{ vars.git_email }}
       # Set the multidev_safe flag. This will create a shorter branch name that
       # is safe to use as a multidev site name.
       multidev_safe: true

--- a/.github/examples/build-test-pull-request-tests.yml
+++ b/.github/examples/build-test-pull-request-tests.yml
@@ -72,8 +72,12 @@ jobs:
     uses: thisisgain/.github/.github/workflows/03-deploy-artifact.yml@main
     with:
       container: registry.gitlab.com/freelygive/docker/drupal-php-node:p8.3-cli-n20
-      git_name: GAIN Automation
-      git_email: geeks+client.gha@thisisgain.com
+      # The commit details should be an automation account, with a shared email;
+      # the SSH config in secrets use these credentials, and the user should be
+      # able to access the remote repo (eg add as a user).
+      # Git user details, including SSH keys, should be stored in Keeper.
+      git_name: ${{ vars.git_name }}
+      git_email: ${{ vars.git_email }}
       source_key: composer
       add_files_defaults: false
       add_files: >-

--- a/.github/examples/deploy-acquia-acli.yml
+++ b/.github/examples/deploy-acquia-acli.yml
@@ -30,8 +30,9 @@ jobs:
       # The commit details should be an automation account, with a shared email;
       # the SSH config in secrets use these credentials, and the user should be
       # able to access the remote repo (eg add as a user).
-      git_name: GAIN Automation
-      git_email: geeks+client.gha@thisisgain.com
+      # Git user details, including SSH keys, should be stored in Keeper.
+      git_name: ${{ vars.git_name }}
+      git_email: ${{ vars.git_email }}
       # The target branch is used for deploying a tag: ACLI requires a push to a
       # branch at the same time. The branch name is automatically detected if
       # this is triggered by a push to a branch.

--- a/.github/examples/deploy-pantheon-default.yml
+++ b/.github/examples/deploy-pantheon-default.yml
@@ -32,8 +32,9 @@ jobs:
       # The commit details should be an automation account, with a shared email;
       # the SSH config in secrets use these credentials, and the user should be
       # able to access the remote repo (eg add as a user).
-      git_name: GAIN Automation
-      git_email: geeks+client.gha@thisisgain.com
+      # Git user details, including SSH keys, should be stored in Keeper.
+      git_name: ${{ vars.git_name }}
+      git_email: ${{ vars.git_email }}
     # If the repository is in the GAIN GitHub, you can use this shortcut to pass
     # all secrets through without needing to define them.
     secrets: inherit

--- a/.github/examples/deploy-release-remote-repository.yml
+++ b/.github/examples/deploy-release-remote-repository.yml
@@ -53,7 +53,9 @@ jobs:
     with:
       target_branch: ${{ inputs.target_branch }}
       push_to_remote: true
-      # The committer in this case is the user who triggered the workflow.
+      # When code is automatically pushed, we use a shared account to associate
+      # the commit/push with. In this case, because a person is triggering the
+      # build and push, the committer is the user who triggered the workflow.
       git_name: ${{ github.event.sender.login }}
       git_email: ${{ github.event.sender.id }}+${{ github.event.sender.login }}@users.noreply.github.com
     secrets:

--- a/.github/workflows/00-acquia-backup-databases.yml
+++ b/.github/workflows/00-acquia-backup-databases.yml
@@ -7,24 +7,24 @@ name: Backup Acquia databases using ACLI.
 on:
   workflow_call:
     inputs:
-      filter:
-        description: 'Optionally, provide a filter for the databases. See: https://docs.acquia.com/acquia-cloud-platform/add-ons/acquia-cli/commands/api:applications:database-list'
-        type: string
-        required: false
       php_version:
         description: 'Optionally, specify a PHP version to install. Default: 8.2.'
         type: string
         required: false
         default: '8.2'
+      filter:
+        description: 'Optionally, provide a filter for the databases. See: https://docs.acquia.com/acquia-cloud-platform/add-ons/acquia-cli/commands/api:applications:database-list'
+        type: string
+        required: false
     secrets:
-      ACQUIA_ENVIRONMENT_ID:
-        description: 'Acquia environment ID.'
-        required: true
       ACLI_CLIENT_ID:
         description: 'The client ID for authenticating with ACLI.'
         required: true
       ACLI_CLIENT_SECRET:
         description: 'The client secret for authenticating with ACLI.'
+        required: true
+      ACQUIA_ENVIRONMENT_ID:
+        description: 'Acquia environment ID.'
         required: true
 
 defaults:

--- a/.github/workflows/00-acquia-backup-databases.yml
+++ b/.github/workflows/00-acquia-backup-databases.yml
@@ -8,10 +8,10 @@ on:
   workflow_call:
     inputs:
       php_version:
-        description: 'Optionally, specify a PHP version to install. Default: 8.2.'
+        description: 'Optionally, specify a PHP version to install. Default: 8.3.'
         type: string
         required: false
-        default: '8.2'
+        default: '8.3'
       filter:
         description: 'Optionally, provide a filter for the databases. See: https://docs.acquia.com/acquia-cloud-platform/add-ons/acquia-cli/commands/api:applications:database-list'
         type: string

--- a/.github/workflows/00-create-ci-settings.yml
+++ b/.github/workflows/00-create-ci-settings.yml
@@ -11,28 +11,18 @@ on:
         description: 'The Docker image to use.'
         type: string
         required: true
-      source_key:
-        description: 'The source cache key suffix, or empty to perform a clean checkout.'
-        type: string
-        default: 'composer'
       target_key:
         description: 'The target cache key suffix, or empty to throw away.'
         type: string
         default: 'settings'
+      source_key:
+        description: 'The source cache key suffix, or empty to perform a clean checkout.'
+        type: string
+        default: 'composer'
       docroot:
         description: 'The docroot where Drupal is installed.'
         type: string
         default: 'docroot'
-    secrets:
-      ACQUIA_ENVIRONMENT_ID:
-        description: 'Acquia environment ID.'
-        required: true
-      ACLI_CLIENT_ID:
-        description: 'The client ID for authenticating with ACLI.'
-        required: true
-      ACLI_CLIENT_SECRET:
-        description: 'The client secret for authenticating with ACLI.'
-        required: true
 
 defaults:
   run:

--- a/.github/workflows/00-drush-site-install.yml
+++ b/.github/workflows/00-drush-site-install.yml
@@ -12,6 +12,26 @@ on:
         description: 'The Docker image to use.'
         type: string
         required: true
+      db_image:
+        description: 'A Docker database image, eg mysql:5.7 or mariadb:10.3. Default: mariadb:10.3.'
+        type: string
+        default: 'mariadb:10.3'
+      db_user:
+        description: 'The database username. Default: db.'
+        type: string
+        default: 'db'
+      db_pass:
+        description: 'The database password. Default: db.'
+        type: string
+        default: 'db'
+      db_name:
+        description: 'The database name. Default: db.'
+        type: string
+        default: 'db'
+      db_root_pass:
+        description: 'The database root password. Default: root.'
+        type: string
+        default: 'root'
       source_key:
         description: 'The source cache key suffix, or empty to perform a clean checkout.'
         type: string
@@ -36,13 +56,13 @@ jobs:
     container: ${{ inputs.container }}
     services:
       db:
-        image: mariadb:10.3
+        image: ${{ inputs.db_image }}
         ports: [3306]
         env:
-          MYSQL_USER: db
-          MYSQL_PASSWORD: db
-          MYSQL_DATABASE: db
-          MYSQL_ROOT_PASSWORD: root
+          MYSQL_USER: ${{ inputs.db_user }}
+          MYSQL_PASSWORD: ${{ inputs.db_pass }}
+          MYSQL_DATABASE: ${{ inputs.db_name }}
+          MYSQL_ROOT_PASSWORD: ${{ inputs.db_root_pass }}
         options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
     steps:
       - name: Disable Git safe directories as we are in a container.

--- a/.github/workflows/00-pantheon-create-multidev.yml
+++ b/.github/workflows/00-pantheon-create-multidev.yml
@@ -51,12 +51,12 @@ jobs:
           strip_prefix: ${{ inputs.strip_prefix }}
           safe_prefix: ${{ inputs.safe_prefix }}
 
-      - name: Install PHP
+      - name: Install PHP.
         uses: shivammathur/setup-php@master
         with:
           php-version: '8.2'
 
-      - name: Install Terminus
+      - name: Install Terminus.
         uses: pantheon-systems/terminus-github-actions@v1
         with:
           pantheon-machine-token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}

--- a/.github/workflows/00-pantheon-create-multidev.yml
+++ b/.github/workflows/00-pantheon-create-multidev.yml
@@ -20,6 +20,11 @@ on:
         type: string
         required: false
         default: 't'
+      php_version:
+        description: 'Optionally, specify a PHP version to install. Default: 8.2.'
+        type: string
+        required: false
+        default: '8.2'
     secrets:
       PANTHEON_MACHINE_TOKEN:
         description: 'Machine token authorised to the Pantheon site.'
@@ -54,7 +59,7 @@ jobs:
       - name: Install PHP.
         uses: shivammathur/setup-php@master
         with:
-          php-version: '8.2'
+          php-version: ${{ inputs.php_version }}
 
       - name: Install Terminus.
         uses: pantheon-systems/terminus-github-actions@v1

--- a/.github/workflows/00-pantheon-create-multidev.yml
+++ b/.github/workflows/00-pantheon-create-multidev.yml
@@ -21,10 +21,10 @@ on:
         required: false
         default: 't'
       php_version:
-        description: 'Optionally, specify a PHP version to install. Default: 8.2.'
+        description: 'Optionally, specify a PHP version to install. Default: 8.3.'
         type: string
         required: false
-        default: '8.2'
+        default: '8.3'
     secrets:
       PANTHEON_MACHINE_TOKEN:
         description: 'Machine token authorised to the Pantheon site.'

--- a/.github/workflows/00-pantheon-remove-branch.yml
+++ b/.github/workflows/00-pantheon-remove-branch.yml
@@ -22,19 +22,11 @@ on:
         required: false
         default: 't'
     secrets:
-      REMOTE_REPO:
-        description: 'The remote repository URL.'
-        required: true
-      REMOTE_SSH_KEY:
-        description: 'Private SSH key authorised to push to the remote repository.'
-        required: true
-      SSH_CONFIG:
-        description: 'SSH configuration. Can be an empty secret, or not included.'
-      KNOWN_HOSTS:
-        description: 'SSH known hosts. Set using `ssh-keyscan` command.'
-        required: true
       PANTHEON_MACHINE_TOKEN:
         description: 'Machine token authorised to the Pantheon site.'
+        required: true
+      REMOTE_REPO:
+        description: 'The remote repository URL.'
         required: true
 
 defaults:
@@ -62,7 +54,7 @@ jobs:
           strip_prefix: ${{ inputs.strip_prefix }}
           safe_prefix: ${{ inputs.safe_prefix }}
 
-      - name: Installing PHP
+      - name: Install PHP.
         uses: shivammathur/setup-php@master
         with:
           php-version: '8.2'
@@ -91,7 +83,7 @@ jobs:
           echo ${multidev_list} >> ${GITHUB_OUTPUT}
           echo "${delimiter}" >> "${GITHUB_OUTPUT}"
 
-      - name: Delete a multidev environment.
+      - name: Delete the multidev environment.
         # If there was a multidev environment, delete it, and the branch.
         if: steps.check_existing.outputs.multidev_list != ''
         continue-on-error: true

--- a/.github/workflows/00-pantheon-remove-branch.yml
+++ b/.github/workflows/00-pantheon-remove-branch.yml
@@ -22,10 +22,10 @@ on:
         required: false
         default: 't'
       php_version:
-        description: 'Optionally, specify a PHP version to install. Default: 8.2.'
+        description: 'Optionally, specify a PHP version to install. Default: 8.3.'
         type: string
         required: false
-        default: '8.2'
+        default: '8.3'
     secrets:
       PANTHEON_MACHINE_TOKEN:
         description: 'Machine token authorised to the Pantheon site.'

--- a/.github/workflows/00-pantheon-remove-branch.yml
+++ b/.github/workflows/00-pantheon-remove-branch.yml
@@ -21,6 +21,11 @@ on:
         type: string
         required: false
         default: 't'
+      php_version:
+        description: 'Optionally, specify a PHP version to install. Default: 8.2.'
+        type: string
+        required: false
+        default: '8.2'
     secrets:
       PANTHEON_MACHINE_TOKEN:
         description: 'Machine token authorised to the Pantheon site.'
@@ -57,7 +62,7 @@ jobs:
       - name: Install PHP.
         uses: shivammathur/setup-php@master
         with:
-          php-version: '8.2'
+          php-version: ${{ inputs.php_version }}
 
       - name: Install Terminus.
         uses: pantheon-systems/terminus-github-actions@v1

--- a/.github/workflows/01-build-composer.yml
+++ b/.github/workflows/01-build-composer.yml
@@ -7,21 +7,21 @@ name: Build and validate Composer.
 on:
   workflow_call:
     inputs:
-      directory:
-        description: 'The directory in which to run commands.'
-        type: string
-        default: './'
       container:
         description: 'The Docker image to use.'
         type: string
         required: true
-      source_key:
-        description: 'The source cache key suffix, or empty to perform a clean checkout.'
+      directory:
+        description: 'The directory in which to run commands.'
         type: string
+        default: './'
       target_key:
         description: 'The target cache key suffix, or empty to throw away.'
         type: string
         default: 'composer'
+      source_key:
+        description: 'The source cache key suffix, or empty to perform a clean checkout.'
+        type: string
       ssh_config:
         description: 'Whether to run SSH configuration for asset access.'
         type: boolean

--- a/.github/workflows/01-build-npm.yml
+++ b/.github/workflows/01-build-npm.yml
@@ -7,17 +7,10 @@ name: Build and validate an NPM package.
 on:
   workflow_call:
     inputs:
-      directory:
-        description: 'The directory in which to run commands.'
-        type: string
-        required: true
       container:
         description: 'The Docker image to use.'
         type: string
         required: true
-      source_key:
-        description: 'The source cache key suffix, or empty to perform a clean checkout.'
-        type: string
       target_key:
         description: 'The target cache key suffix, or empty to throw away.'
         type: string
@@ -26,14 +19,17 @@ on:
         description: 'The target path for the cache.'
         type: string
         default: './*'
-      target_modules:
-        description: 'Whether to keep the `node_modules` directory from the target build.'
-        type: boolean
-        default: true
+      source_key:
+        description: 'The source cache key suffix, or empty to perform a clean checkout.'
+        type: string
       ssh_config:
         description: 'Whether to run SSH configuration for asset access.'
         type: boolean
         default: false
+      directory:
+        description: 'The directory in which to run commands.'
+        type: string
+        required: true
       run_build:
         description: 'Whether to run `npm run build`.'
         type: boolean
@@ -46,6 +42,10 @@ on:
         description: 'Whether to run `npm run test`.'
         type: boolean
         default: false
+      target_modules:
+        description: 'Whether to keep the `node_modules` directory from the target build.'
+        type: boolean
+        default: true
     secrets:
       REMOTE_SSH_KEY:
         description: 'Private SSH key to retrieve any authenticated assets.'

--- a/.github/workflows/02-test-blt.yml
+++ b/.github/workflows/02-test-blt.yml
@@ -16,6 +16,26 @@ on:
         description: 'The source cache key suffix, or empty to perform a clean checkout.'
         type: string
         default: 'composer'
+      db_image:
+        description: 'A Docker database image, eg mysql:5.7 or mariadb:10.3. Default: mysql:5.7.'
+        type: string
+        default: 'mysql:5.7'
+      db_user:
+        description: 'The database username. Default: db.'
+        type: string
+        default: 'db'
+      db_pass:
+        description: 'The database password. Default: db.'
+        type: string
+        default: 'db'
+      db_name:
+        description: 'The database name. Default: db.'
+        type: string
+        default: 'db'
+      db_root_pass:
+        description: 'The database root password. Default: root.'
+        type: string
+        default: 'root'
       copy_ci_settings:
         description: 'Whether to copy the settings.ci.php to settings.local.php.'
         type: boolean
@@ -58,13 +78,13 @@ jobs:
     container: ${{ inputs.container }}
     services:
       db:
-        image: mysql:5.7
+        image: ${{ inputs.db_image }}
         ports: [ 3306 ]
         env:
-          MYSQL_USER: db
-          MYSQL_PASSWORD: db
-          MYSQL_DATABASE: db
-          MYSQL_ROOT_PASSWORD: root
+          MYSQL_USER: ${{ inputs.db_user }}
+          MYSQL_PASSWORD: ${{ inputs.db_pass }}
+          MYSQL_DATABASE: ${{ inputs.db_name }}
+          MYSQL_ROOT_PASSWORD: ${{ inputs.db_root_pass }}
         options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
     steps:
       - name: Restore build from a previous step.

--- a/.github/workflows/02-test-composer-security.yml
+++ b/.github/workflows/02-test-composer-security.yml
@@ -7,10 +7,6 @@ name: Run Composer security checks.
 on:
   workflow_call:
     inputs:
-      directory:
-        description: 'The directory in which to run commands.'
-        type: string
-        default: './'
       container:
         description: 'The Docker image to use.'
         type: string
@@ -19,6 +15,10 @@ on:
         description: 'The source cache key suffix, or empty to perform a clean checkout.'
         type: string
         default: 'composer'
+      directory:
+        description: 'The directory in which to run commands.'
+        type: string
+        default: './'
 
 defaults:
   run:

--- a/.github/workflows/02-test-drupal-cypress.yml
+++ b/.github/workflows/02-test-drupal-cypress.yml
@@ -31,22 +31,22 @@ on:
         description: 'The database root password.'
         type: string
         default: 'root'
-      source_key:
-        description: 'The source cache key suffix, or empty to perform a clean checkout.'
-        type: string
-        default: 'composer'
       source_path:
         description: 'The path of the source cache.'
         type: string
         default: ./*
-      docroot:
-        description: 'The docroot where Drupal is installed.'
+      source_key:
+        description: 'The source cache key suffix, or empty to perform a clean checkout.'
         type: string
-        default: 'docroot'
+        default: 'composer'
       base_url:
         description: 'The non-prefixed local base URL, eg website.ddev.site.'
         type: string
         required: true
+      docroot:
+        description: 'The docroot where Drupal is installed.'
+        type: string
+        default: 'docroot'
 
 defaults:
   run:

--- a/.github/workflows/02-test-drupal-cypress.yml
+++ b/.github/workflows/02-test-drupal-cypress.yml
@@ -12,23 +12,23 @@ on:
         type: string
         required: true
       db_image:
-        description: 'The database Docker image to use.'
+        description: 'A Docker database image, eg mysql:5.7 or mariadb:10.3. Default: mysql:5.7.'
         type: string
         default: 'mysql:5.7'
       db_user:
-        description: 'The database username.'
+        description: 'The database username. Default: db.'
         type: string
         default: 'db'
       db_pass:
-        description: 'The database password.'
+        description: 'The database password. Default: db.'
         type: string
         default: 'db'
       db_name:
-        description: 'The database name.'
+        description: 'The database name. Default: db.'
         type: string
         default: 'db'
       db_root_pass:
-        description: 'The database root password.'
+        description: 'The database root password. Default: root.'
         type: string
         default: 'root'
       source_path:

--- a/.github/workflows/02-test-drupal-postman.yml
+++ b/.github/workflows/02-test-drupal-postman.yml
@@ -31,14 +31,14 @@ on:
         description: 'The database root password.'
         type: string
         default: 'root'
-      source_key:
-        description: 'The source cache key suffix, or empty to perform a clean checkout.'
-        type: string
-        default: 'composer'
       source_path:
         description: 'The path of the source cache.'
         type: string
         default: ./*
+      source_key:
+        description: 'The source cache key suffix, or empty to perform a clean checkout.'
+        type: string
+        default: 'composer'
       docroot:
         description: 'The docroot where Drupal is installed.'
         type: string

--- a/.github/workflows/02-test-drupal-postman.yml
+++ b/.github/workflows/02-test-drupal-postman.yml
@@ -12,23 +12,23 @@ on:
         type: string
         required: true
       db_image:
-        description: 'The database Docker image to use.'
+        description: 'A Docker database image, eg mysql:5.7 or mariadb:10.3. Default: mysql:5.7.'
         type: string
         default: 'mysql:5.7'
       db_user:
-        description: 'The database username.'
+        description: 'The database username. Default: db.'
         type: string
         default: 'db'
       db_pass:
-        description: 'The database password.'
+        description: 'The database password. Default: db.'
         type: string
         default: 'db'
       db_name:
-        description: 'The database name.'
+        description: 'The database name. Default: db.'
         type: string
         default: 'db'
       db_root_pass:
-        description: 'The database root password.'
+        description: 'The database root password. Default: root.'
         type: string
         default: 'root'
       source_path:

--- a/.github/workflows/02-test-npm-audit.yml
+++ b/.github/workflows/02-test-npm-audit.yml
@@ -7,26 +7,26 @@ name: Run NPM audit and analysis.
 on:
   workflow_call:
     inputs:
-      directory:
-        description: 'The directory in which to run commands.'
-        type: string
-        default: './'
-      container:
-        description: 'The Docker image to use.'
-        type: string
-        required: true
-      source_key:
-        description: 'The source cache key suffix, or empty to perform a clean checkout.'
-        type: string
-        default: 'npm'
-      source_path:
-        description: 'The path of the source cache.'
-        type: string
-        default: ./*
       audit:
         description: 'Whether to run `npm audit`.'
         type: boolean
         default: true
+      container:
+        description: 'The Docker image to use.'
+        type: string
+        required: true
+      source_path:
+        description: 'The path of the source cache.'
+        type: string
+        default: ./*
+      source_key:
+        description: 'The source cache key suffix, or empty to perform a clean checkout.'
+        type: string
+        default: 'npm'
+      directory:
+        description: 'The directory in which to run commands.'
+        type: string
+        default: './'
       lint:
         description: 'The lint script name, or empty to disable.'
         type: string

--- a/.github/workflows/02-test-php-analysis.yml
+++ b/.github/workflows/02-test-php-analysis.yml
@@ -8,10 +8,10 @@ name: Run PHP static analysis.
 on:
   workflow_call:
     inputs:
-      directory:
-        description: 'The directory in which to run commands.'
-        type: string
-        default: './'
+      phpcs:
+        description: 'Whether to run PHP Coding Standards checks.'
+        type: boolean
+        default: true
       container:
         description: 'The Docker image to use.'
         type: string
@@ -20,10 +20,10 @@ on:
         description: 'The source cache key suffix, or empty to perform a clean checkout.'
         type: string
         default: 'composer'
-      phpcs:
-        description: 'Whether to run PHP Coding Standards checks.'
-        type: boolean
-        default: true
+      directory:
+        description: 'The directory in which to run commands.'
+        type: string
+        default: './'
       phpstan:
         description: 'Whether to run PHPStan checks.'
         type: boolean

--- a/.github/workflows/02-test-php-analysis.yml
+++ b/.github/workflows/02-test-php-analysis.yml
@@ -68,6 +68,9 @@ jobs:
         run: exit 1
         if: steps.restore-build.outputs.cache-hit != 'true'
 
+      - name: Abort if PHPCS isn't installed.
+        run: test -f ./vendor/bin/phpcs || exit 1
+
       - name: Run PHPCS.
         run: |
           cd ${{ inputs.directory }}
@@ -90,6 +93,9 @@ jobs:
       - name: Abort if we have a source build cache miss.
         run: exit 1
         if: steps.restore-build.outputs.cache-hit != 'true'
+
+      - name: Abort if PHPStan isn't installed.
+        run: test -f ./vendor/bin/phpstan || exit 1
 
       - name: Run PHPStan.
         run: |
@@ -114,6 +120,9 @@ jobs:
         run: exit 1
         if: steps.restore-build.outputs.cache-hit != 'true'
 
+      - name: Abort if GrumPHP isn't installed.
+        run: test -f ./vendor/bin/grumphp || exit 1
+
       - name: Run GrumPHP checks.
         run: |
           cd ${{ inputs.directory }}
@@ -136,6 +145,9 @@ jobs:
       - name: Abort if we have a source build cache miss.
         run: exit 1
         if: steps.restore-build.outputs.cache-hit != 'true'
+
+      - name: Abort if Drupal Check isn't installed.
+        run: test -f ./vendor/bin/drupal-check || exit 1
 
       - name: Run Drupal Check.
         run: |

--- a/.github/workflows/02-test-php-phpunit.yml
+++ b/.github/workflows/02-test-php-phpunit.yml
@@ -7,10 +7,6 @@ name: Run automated PHPUnit tests.
 on:
   workflow_call:
     inputs:
-      directory:
-        description: 'The directory in which to run commands.'
-        type: string
-        default: './'
       container:
         description: 'The Docker image to use.'
         type: string
@@ -19,6 +15,10 @@ on:
         description: 'The source cache key suffix, or empty to perform a clean checkout.'
         type: string
         default: 'composer'
+      directory:
+        description: 'The directory in which to run commands.'
+        type: string
+        default: './'
 
 defaults:
   run:

--- a/.github/workflows/02-test-php-phpunit.yml
+++ b/.github/workflows/02-test-php-phpunit.yml
@@ -52,6 +52,9 @@ jobs:
         run: exit 1
         if: steps.restore-build.outputs.cache-hit != 'true'
 
+      - name: Abort if PHPUnit isn't installed.
+        run: test -f ./vendor/bin/phpunit || exit 1
+
       - name: Start the PHP server.
         run: |
           cd ${{ inputs.directory }}

--- a/.github/workflows/02-test-php-phpunit.yml
+++ b/.github/workflows/02-test-php-phpunit.yml
@@ -11,6 +11,26 @@ on:
         description: 'The Docker image to use.'
         type: string
         required: true
+      db_image:
+        description: 'A Docker database image, eg mysql:5.7 or mariadb:10.3. Default: mysql:5.7.'
+        type: string
+        default: 'mysql:5.7'
+      db_user:
+        description: 'The database username. Default: db.'
+        type: string
+        default: 'db'
+      db_pass:
+        description: 'The database password. Default: db.'
+        type: string
+        default: 'db'
+      db_name:
+        description: 'The database name. Default: db.'
+        type: string
+        default: 'db'
+      db_root_pass:
+        description: 'The database root password. Default: root.'
+        type: string
+        default: 'root'
       source_key:
         description: 'The source cache key suffix, or empty to perform a clean checkout.'
         type: string
@@ -31,13 +51,13 @@ jobs:
     container: ${{ inputs.container }}
     services:
       db:
-        image: mysql:5.7
+        image: ${{ inputs.db_image }}
         ports: [ 3306 ]
         env:
-          MYSQL_USER: db
-          MYSQL_PASSWORD: db
-          MYSQL_DATABASE: db
-          MYSQL_ROOT_PASSWORD: root
+          MYSQL_USER: ${{ inputs.db_user }}
+          MYSQL_PASSWORD: ${{ inputs.db_pass }}
+          MYSQL_DATABASE: ${{ inputs.db_name }}
+          MYSQL_ROOT_PASSWORD: ${{ inputs.db_root_pass }}
         options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
     steps:
       - name: Restore build from a previous step.

--- a/.github/workflows/03-deploy-acli.yml
+++ b/.github/workflows/03-deploy-acli.yml
@@ -24,15 +24,7 @@ on:
         type: string
         required: false
         default: '8.2'
-      directory:
-        description: 'Optionally, the directory to check for git diffs.'
-        type: string
-        required: false
-        default: './'
     secrets:
-      REMOTE_REPO:
-        description: 'The remote repository URL.'
-        required: true
       REMOTE_SSH_KEY:
         description: 'Private SSH key authorised to push to the remote repository.'
         required: true
@@ -46,6 +38,9 @@ on:
         required: true
       ACLI_CLIENT_SECRET:
         description: 'The client secret for authenticating with ACLI.'
+        required: true
+      REMOTE_REPO:
+        description: 'The remote repository URL.'
         required: true
 
 defaults:

--- a/.github/workflows/03-deploy-acli.yml
+++ b/.github/workflows/03-deploy-acli.yml
@@ -20,10 +20,10 @@ on:
         type: string
         required: false
       php_version:
-        description: 'Optionally, specify a PHP version to install. Default: 8.2.'
+        description: 'Optionally, specify a PHP version to install. Default: 8.3.'
         type: string
         required: false
-        default: '8.2'
+        default: '8.3'
     secrets:
       REMOTE_SSH_KEY:
         description: 'Private SSH key authorised to push to the remote repository.'

--- a/.github/workflows/03-deploy-artifact.yml
+++ b/.github/workflows/03-deploy-artifact.yml
@@ -23,20 +23,6 @@ on:
       source_key:
         description: 'The source cache key suffix, or empty to perform a clean checkout.'
         type: string
-      add_files:
-        description: 'The files/directories to commit, bypassing .gitignore.'
-        type: string
-      add_files_defaults:
-        description: 'Whether to commit the default set of files (vendor and docroot).'
-        type: boolean
-        default: true
-      remove_files:
-        description: 'The files/directories to remove from deployment.'
-        type: string
-      remove_files_defaults:
-        description: 'Whether to remove the default set of files (DDEV, Github and patch directories, plus some Drupal Core files).'
-        type: boolean
-        default: true
       directory:
         description: 'The directory in which to run commands.'
         type: string
@@ -45,9 +31,23 @@ on:
         description: 'Additional options to pass to Composer.'
         type: string
         default: '-o --apcu-autoloader'
+      add_files_defaults:
+        description: 'Whether to commit the default set of files (vendor and docroot).'
+        type: boolean
+        default: true
+      add_files:
+        description: 'The files/directories to commit, bypassing .gitignore.'
+        type: string
+      remove_files_defaults:
+        description: 'Whether to remove the default set of files (DDEV, Github and patch directories, plus some Drupal Core files).'
+        type: boolean
+        default: true
+      remove_files:
+        description: 'The files/directories to remove from deployment.'
+        type: string
     secrets:
-      REMOTE_REPO:
-        description: 'The remote repository URL.'
+      GITHUB_ACCESS_TOKEN:
+        description: 'The read access token for Github, required for the unshallow fetch.'
         required: true
       REMOTE_SSH_KEY:
         description: 'Private SSH key authorised to push to the remote repository.'
@@ -57,8 +57,8 @@ on:
       KNOWN_HOSTS:
         description: 'SSH known hosts. Set using `ssh-keyscan` command.'
         required: true
-      GITHUB_ACCESS_TOKEN:
-        description: 'The read access token for Github, required for the unshallow fetch.'
+      REMOTE_REPO:
+        description: 'The remote repository URL.'
         required: true
 
 defaults:

--- a/.github/workflows/03-deploy-blt.yml
+++ b/.github/workflows/03-deploy-blt.yml
@@ -12,6 +12,10 @@ on:
         description: 'The Docker image to use.'
         type: string
         required: true
+      dry_run:
+        description: 'Whether this should be a dry-run only (no push to artifact repo).'
+        type: boolean
+        required: true
       git_name:
         description: "The Git committer name. Can be hardcoded, or get the triggering user's name."
         type: string
@@ -19,10 +23,6 @@ on:
       git_email:
         description: "The Git committer email. Can be hardcoded, or get the triggering user's email."
         type: string
-        required: true
-      dry_run:
-        description: 'Whether this should be a dry-run only (no push to artifact repo).'
-        type: boolean
         required: true
       source_key:
         description: 'The source cache key suffix, or empty to perform a clean checkout.'
@@ -88,7 +88,7 @@ jobs:
         run: |
           echo "COMMIT_SHA=`git log -1 --pretty=format:"%s" | cut -d' ' -f2`" >> $GITHUB_ENV
           echo "COMMIT_REF=refs/heads/$COMMIT_BRANCH" >> $GITHUB_ENV
-          echo "COMMIT_MSG=`curl -H 'authorization: Bearer ${{ secrets.GITHUB_ACCESS_TOKEN }}' https://api.github.com/repos/${{ github.repository }}/commits/$COMMIT_BRANCH | grep '"message":' | grep -oE ': ".*",' | cut -c4- | rev | cut -c3- | rev`" >> $GITHUB_ENV
+          echo "COMMIT_MSG=`curl -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/${{ github.repository }}/commits/$COMMIT_BRANCH | grep '"message":' | grep -oE ': ".*",' | cut -c4- | rev | cut -c3- | rev`" >> $GITHUB_ENV
 
       - name: Get Composer Cache Directory
         run: |

--- a/.github/workflows/03-deploy-git-push.yml
+++ b/.github/workflows/03-deploy-git-push.yml
@@ -12,9 +12,6 @@ on:
         type: string
         required: false
     secrets:
-      REMOTE_REPO:
-        description: 'The remote repository URL.'
-        required: true
       REMOTE_SSH_KEY:
         description: 'Private SSH key authorised to push to the remote repository.'
         required: true
@@ -22,6 +19,9 @@ on:
         description: 'SSH configuration. Can be an empty secret, or not included.'
       KNOWN_HOSTS:
         description: 'SSH known hosts. Set using `ssh-keyscan` command.'
+        required: true
+      REMOTE_REPO:
+        description: 'The remote repository URL.'
         required: true
 
 defaults:
@@ -33,7 +33,7 @@ jobs:
     name: 'Push code to remote repository'
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the code
+      - name: Check out the code.
         uses: actions/checkout@v6
         with:
           # Ensure PRs check out the right commit.
@@ -41,15 +41,15 @@ jobs:
           # Perform a full checkout to prevent orphaned commits.
           fetch-depth: 0
 
-      - name: Set up the SSH key and configuration
+      - name: Set up the SSH key and configuration.
         uses: shimataro/ssh-key-action@v2
         with:
           key: ${{ secrets.REMOTE_SSH_KEY }}
           config: ${{ secrets.SSH_CONFIG }}
           known_hosts: ${{ secrets.KNOWN_HOSTS }}
 
-      - name: Add the Git remote
+      - name: Add the Git remote.
         run: git remote add target ${{ secrets.REMOTE_REPO }}
 
-      - name: Push code
+      - name: Push code.
         run: git push target HEAD:${{ inputs.target_ref || (github.event.pull_request.head.ref && format('refs/heads/{0}', github.event.pull_request.head.ref) ) || github.ref }} --force

--- a/.github/workflows/03-deploy-git-update.yml
+++ b/.github/workflows/03-deploy-git-update.yml
@@ -8,14 +8,14 @@ name: Push code to a branch on a remote repository.
 on:
   workflow_call:
     inputs:
-      target_branch:
-        description: 'The target branch to compare and deploy to.'
-        type: string
-        required: true
       push_to_remote:
         description: 'Whether to push to the remote repository.'
         type: boolean
         default: false
+      target_branch:
+        description: 'The target branch to compare and deploy to.'
+        type: string
+        required: true
       git_name:
         description: "The Git committer name. Can be hardcoded, or get the triggering user's name."
         type: string
@@ -27,14 +27,14 @@ on:
     secrets:
       GITHUB_ACCESS_TOKEN:
         description: 'The write access token for the Git repo. Required for GitHub repo.'
-      REMOTE_REPO:
-        description: 'The remote repository URL. Required to push to remote repo.'
       REMOTE_SSH_KEY:
         description: 'Private SSH key authorised to push to the remote repository. Required to push to remote repo.'
       SSH_CONFIG:
         description: 'SSH configuration. Can be an empty value. Required to push to remote repo.'
       KNOWN_HOSTS:
         description: 'SSH known hosts. Set using `ssh-keyscan` command. Required to push to remote repo.'
+      REMOTE_REPO:
+        description: 'The remote repository URL. Required to push to remote repo.'
 
 defaults:
   run:
@@ -45,20 +45,20 @@ jobs:
     name: 'Push branch to repo'
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the code with a token
+      - name: Check out the code with a token.
         uses: actions/checkout@v6
         if: ${{ !inputs.push_to_remote }}
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_ACCESS_TOKEN }}
 
-      - name: Check out the code without a token
+      - name: Check out the code without a token.
         uses: actions/checkout@v6
         if: ${{ inputs.push_to_remote }}
         with:
           fetch-depth: 0
 
-      - name: Set up the SSH key and configuration
+      - name: Set up the SSH key and configuration.
         if: ${{ inputs.push_to_remote }}
         uses: shimataro/ssh-key-action@v2
         with:
@@ -66,16 +66,16 @@ jobs:
           config: ${{ secrets.SSH_CONFIG }}
           known_hosts: ${{ secrets.KNOWN_HOSTS }}
 
-      - name: Fetch the remote branches
+      - name: Fetch the remote branches.
         if: ${{ inputs.push_to_remote }}
         run: |
           git remote add target ${{ secrets.REMOTE_REPO }}
           git fetch target
 
-      - name: Checkout the target branch, creating if necessary
+      - name: Checkout the target branch, creating if necessary.
         run: git checkout ${{ inputs.target_branch }} || git checkout -b ${{ inputs.target_branch }}
 
-      - name: Update the code to the ref we are deploying
+      - name: Update the code to the ref we are deploying.
         # Checkout of a target branch will only check out changes within that
         # branch, which means removed files don't get removed. We handle that
         # with a check and remove. We also use the sha specifically to avoid
@@ -85,13 +85,13 @@ jobs:
           git checkout ${{ github.sha }} -- .
           git diff ${{ github.sha }} --name-only | tr '\n' '\0' | xargs -0 -r git rm
 
-      - name: Ensure everything matches before proceeding
+      - name: Ensure everything matches before proceeding.
         run: |
           git config --global --add safe.directory $(realpath .)
           git diff ${{ github.sha }}
           git diff-index --quiet ${{ github.sha }}
 
-      - name: Commit the changes if ref is a branch
+      - name: Commit the changes if ref is a branch.
         if: startsWith(github.ref, 'refs/heads/')
         env:
           GITHUB_REF: ${{ github.ref }}
@@ -102,7 +102,7 @@ jobs:
           GIT_COMMITTER_EMAIL: ${{ inputs.git_email }}
         run: git commit -m "Deploy ${GITHUB_REF:11} [${GITHUB_SHA:0:7}]" --allow-empty
 
-      - name: Commit the changes if ref is a tag
+      - name: Commit the changes if ref is a tag.
         if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_REF: ${{ github.ref }}
@@ -112,10 +112,10 @@ jobs:
           GIT_COMMITTER_EMAIL: ${{ inputs.git_email }}
         run: git commit -m "Release ${GITHUB_REF:10}" --allow-empty
 
-      - name: Push the branch to Github
+      - name: Push the branch to Github.
         if: ${{ !inputs.push_to_remote }}
         run: git push origin ${{ inputs.target_branch }}
 
-      - name: Push the branch to the remote repository
+      - name: Push the branch to the remote repository.
         if: ${{ inputs.push_to_remote }}
         run: git push target ${{ inputs.target_branch }}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ starting point for building your own GitHub Actions workflows.
     - [Adding jobs to a workflow](#adding-jobs-to-a-workflow)
     - [Choosing which jobs to add](#choosing-which-jobs-to-add)
     - [Running a workflow](#running-a-workflow)
-  - [Secrets in jobs](#secrets-in-jobs)
+  - [Secrets and variables in jobs](#secrets-and-variables-in-jobs)
+    - [Secrets](#secrets)
+    - [Variables](#variables)
   - [Customising jobs](#customising-jobs)
   - [Further reading](#further-reading)
 
@@ -217,14 +219,55 @@ trigger a workflow from the Actions page in the repository. Be careful with
 this: if any jobs within the workflow use references that only exist on a
 pull request, the workflow will fail to run.
 
-## Secrets in jobs
+## Secrets and variables in jobs
 
-Some workflows require secrets to be added to your GitHub repository. You need
-to be a repo admin to be able to set up these keys.
+Some workflows require variables or secrets to be added to your GitHub
+repository. You need to be a repo admin to be able to set up these values.
 
-Go to Settings > Secrets and variables > Actions to set the variables. They
-should be added as Repository secrets. The workflow includes the variable name
-but the value will differ.
+Go to Settings > Secrets and variables > Actions to set these values. They
+should be added as Repository values/secrets. The workflow includes the variable
+name but the value will differ.
+
+There are two types of variables you can add:
+
+* **Variable**: non-sensitive values. These are more visible during workflow
+  runs, so it's a little easier to see/debug them. For example, Github user
+  details, or the remote repository URL.
+* **Secret**: sensitive values that should not be exposed/visible during runs.
+  These won't ever be printed or displayed during workflow runs. For example,
+  SSH keys or access tokens.
+
+You can always be defensive and use secrets for all values, but **never**
+downgrade sensitive data to a variable instead of a secret. Decide whether the
+value should be a secret or variable by checking the workflow you're planning
+to use [in the `workflows` directory](./workflows).
+
+### Secrets
+
+Check the workflow and look for a section at the top of the file:
+
+```yml
+on:
+  workflow_call:
+    secrets:
+      ACQUIA_ENVIRONMENT_ID:
+        description: 'Acquia environment ID.'
+        required: true
+```
+
+This means that when calling the workflow you will meed to define the secrets
+listed:
+
+```yml
+jobs:
+  backup-databases:
+    name: 'Task: Backup production databases'
+    uses: thisisgain/.github/.github/workflows/00-acquia-backup-databases.yml@main
+    secrets:
+      ACQUIA_ENVIRONMENT_ID: ${{ secrets.ACQUIA_ENVIRONMENT_ID }}
+```
+
+Secrets are referenced in the workflow as `${{ secrets.NAME }}`.
 
 | Name                     | Description |
 | ------------------------ | ----------- |
@@ -235,7 +278,7 @@ but the value will differ.
 | **Remote repository**                  |
 | `REMOTE_REPO`            | The URL of the remote/target repository, where the work should be deployed to. |
 | `REMOTE_SSH_KEY`         | A private SSH key authorised to push to the remote repository. |
-| `GITHUB_ACCESS_TOKEN`      | A GitHub access token authorised to interact with a remote repository. Normally, pass in `${{ secrets.GITHUB_TOKEN }}``. |
+| `GITHUB_ACCESS_TOKEN`      | A GitHub access token authorised to interact with a remote repository. Unless otherwise specified, use the Github-created secret `${{ secrets.GITHUB_TOKEN }}``. |
 | **Hosting specific: Acquia**           |
 | `ACQUIA_ENVIRONMENT_ID`  | The Acquia environment ID. |
 | `ACLI_CLIENT_ID`         | A client ID for authenticating with Acquia CLI. |
@@ -244,27 +287,39 @@ but the value will differ.
 | `PANTHEON_MACHINE_NAME`  | The machine name for the Pantheon project. |
 | `PANTHEON_MACHINE_TOKEN` | A machine token authorised to interact with the Pantheon project via Terminus. |
 
-Some workflows may need additional configuration to be set during runtime. If an
-input variable is marked as a secret, it will come from the Github secrets.
-Secret values should not be used to populate regular inputs. See the individual
-workflows to find out what input variables are available for customising the
-build:
+### Variables
+
+If the variable is listed under the `inputs` section:
 
 ```yml
-deploy:
-  name: 'Deploy: push code to remote environment.'
-  uses: thisisgain/.github/.github/workflows/03-deploy-git-update.yml@main
-  with:
-    target_branch: ${{ inputs.target_branch }}
-    push_to_remote: true
-    git_name: ${{ github.event.sender.login }}
-    git_email: ${{ github.event.sender.id }}+${{ github.event.sender.login }}@users.noreply.github.com
-  secrets:
-    REMOTE_REPO: ${{ secrets.REMOTE_REPO }}
-    REMOTE_SSH_KEY: ${{ secrets.REMOTE_SSH_KEY }}
-    SSH_CONFIG: ${{ secrets.SSH_CONFIG }}
-    KNOWN_HOSTS: ${{ secrets.KNOWN_HOSTS }}
+on:
+  workflow_call:
+    inputs:
+      git_name:
+        description: "The Git committer name. Can be hardcoded, or get the triggering user's name."
+        type: string
+        required: true
 ```
+
+This is a candidate for setting a variable, particularly if it will be reused
+across multiple workflows. Inputs can be passed in when calling the workflow:
+
+```yml
+jobs:
+  push-code:
+    name: 'Deploy: push artifact to repository.'
+    uses: thisisgain/.github/.github/workflows/03-deploy-artifact.yml@main
+    with:
+      git_name: ${{ vars.GIT_NAME }}
+```
+
+Variables are referenced in the workflow as `${{ vars.NAME }}`.
+
+| Name                     | Description |
+| ------------------------ | ----------- |
+| **General**                            |
+| `GIT_USER`             | The username for the user making the automated commits. Usually `GAIN Automation`. |
+| `GIT_EMAIL`            | The password for the user making the automated commits. Usually `geeks+CLIENT.gha@thisisgain.com`. |
 
 ## Customising jobs
 


### PR DESCRIPTION
* Rearranged the input variables/secrets in workflows so that they're ordered in the same way they're used in the actual jobs.
* Corrected some typos.
* Added "Abort" steps for some workflows.
  - If someone enables one of the scanning workflows (eg `phpstan`), but it's not installed in the repo, the workflow will fail.
  - Marked it to exit if the dependency isn't installed, to hopefully make it a little clearer to people who might have enabled it without realising.
  - ... hopefully this doesn't break :grimacing:
* Added database/PHP version configuration to more workflows, and upgraded to PHP 8.3 as default, as this is the version used in all example workflows.
* Switched Git user details to variables (`${{ vars.GIT_NAME }}` for example) instead of hardcoding them.
  - This shouldn't affect any existing workflows.
  - Updated README with more detail/information about secrets vs variables.